### PR TITLE
Create Overview HTML Page that includes all Images in Illustration Folder

### DIFF
--- a/.github/workflows/create_illustration_overview.yml
+++ b/.github/workflows/create_illustration_overview.yml
@@ -1,0 +1,36 @@
+name: Create Illustration Overview
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Assets/Illustrations/**
+
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        working-directory: Assets/Illustrations/create_illustration_page
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Create Illustration Page
+        working-directory: Assets/Illustrations/create_illustration_page
+        run: |
+          python ./create_illustration_page.py
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./Assets/Illustrations

--- a/Assets/Illustrations/create_illustration_page/create_illustration_page.py
+++ b/Assets/Illustrations/create_illustration_page/create_illustration_page.py
@@ -35,7 +35,8 @@ print('Document Title: ', documentTitle)
 images = glob.glob(inputDirectory + '/*.png')
 
 with document(title=documentTitle) as doc:
-    h1(documentTitle)
+    h1(a(documentTitle, href="https://github.com/theliberators/usergroups/tree/main/Assets/Illustrations"))
+
     for path in images:
         span(img(src=os.path.basename(path), style="width:30%"), _class='photo')
 

--- a/Assets/Illustrations/create_illustration_page/create_illustration_page.py
+++ b/Assets/Illustrations/create_illustration_page/create_illustration_page.py
@@ -35,12 +35,17 @@ print('Document Title: ', documentTitle)
 # Possible Image File Types
 types = ('*.png', '*.jpeg', '*.jpg')
 
+# url for links
+illustration_url = "https://github.com/theliberators/usergroups/tree/main/Assets/Illustrations"
+
 with document(title=documentTitle) as doc:
-    h1(a(documentTitle, href="https://github.com/theliberators/usergroups/tree/main/Assets/Illustrations"))
+    h1(a(documentTitle, href=illustration_url))
 
     for image_type in types:
         for path in glob.glob(inputDirectory + '/' + image_type):
-            span(img(src=os.path.basename(path), style="width:30%"), _class='photo')
+            image_filename = os.path.basename(path)
+            image_url = os.path.join(illustration_url, image_filename)
+            span(a(img(src=image_filename, style="width:30%"), href=image_url, target="_blank"), _class='photo')
 
 with doc.head:
     link(rel='stylesheet', href='style.css')

--- a/Assets/Illustrations/create_illustration_page/create_illustration_page.py
+++ b/Assets/Illustrations/create_illustration_page/create_illustration_page.py
@@ -22,23 +22,25 @@ scriptDirectory = os.path.dirname(os.path.realpath(__file__))
 inputDirectory = os.path.join(scriptDirectory, "../")
 documentTitle = "The Liberators Illustrations"
 
-if len(sys.argv) == 4:
+if len(sys.argv) == 3:
     print('Using custom input directory and document title')
     inputDirectory = sys.argv[1]
-    documentTitle = sys.argv[3]
+    documentTitle = sys.argv[2]
 
 outputFile = os.path.join(inputDirectory, "index.html")
 print('Input Directory: ', inputDirectory)
 print('Output File: ', outputFile)
 print('Document Title: ', documentTitle)
 
-images = glob.glob(inputDirectory + '/*.png')
+# Possible Image File Types
+types = ('*.png', '*.jpeg', '*.jpg')
 
 with document(title=documentTitle) as doc:
     h1(a(documentTitle, href="https://github.com/theliberators/usergroups/tree/main/Assets/Illustrations"))
 
-    for path in images:
-        span(img(src=os.path.basename(path), style="width:30%"), _class='photo')
+    for image_type in types:
+        for path in glob.glob(inputDirectory + '/' + image_type):
+            span(img(src=os.path.basename(path), style="width:30%"), _class='photo')
 
 with doc.head:
     link(rel='stylesheet', href='style.css')

--- a/Assets/Illustrations/create_illustration_page/create_illustration_page.py
+++ b/Assets/Illustrations/create_illustration_page/create_illustration_page.py
@@ -1,0 +1,47 @@
+import glob
+from dominate import document
+from dominate.tags import *
+import sys
+import os
+
+# Script that creates an html file that displays all images of a specified folder.
+
+# Styles could be supplied via styles.css file.
+# -----------------------
+# prerequisite: dominate
+# pip install dominate OR pip install --no-cache-dir -r requirements.txt
+# -----------------------
+
+# Inputs:
+# 1: input directory (folder containing images)
+# 2: document title (header displayed on top)
+# Output:
+# index.html will be created next to the images - Keep file in there as paths in index.html are relative
+
+scriptDirectory = os.path.dirname(os.path.realpath(__file__))
+inputDirectory = os.path.join(scriptDirectory, "../")
+documentTitle = "The Liberators Illustrations"
+
+if len(sys.argv) == 4:
+    print('Using custom input directory and document title')
+    inputDirectory = sys.argv[1]
+    documentTitle = sys.argv[3]
+
+outputFile = os.path.join(inputDirectory, "index.html")
+print('Input Directory: ', inputDirectory)
+print('Output File: ', outputFile)
+print('Document Title: ', documentTitle)
+
+images = glob.glob(inputDirectory + '/*.png')
+
+with document(title=documentTitle) as doc:
+    h1(documentTitle)
+    for path in images:
+        span(img(src=os.path.basename(path), style="width:30%"), _class='photo')
+
+with doc.head:
+    link(rel='stylesheet', href='style.css')
+
+
+with open(outputFile, 'w') as f:
+    f.write(doc.render())

--- a/Assets/Illustrations/create_illustration_page/requirements.txt
+++ b/Assets/Illustrations/create_illustration_page/requirements.txt
@@ -1,0 +1,1 @@
+dominate


### PR DESCRIPTION
- Add a python script that creates an index.thml page that includes all *png images in the Illustration folder
- Create a github Actions workflow that automatically publishes a new version on change to a branch called _gh-pages_

In order to make the Illustrations easily accessible you can set up the github repo to serve a "page" that points to the _gh-pages_ branch. This will then be updated everytime anything is changed in the illustration folder.
![Setup Pages](https://user-images.githubusercontent.com/5486874/120894755-5f954700-c61a-11eb-8834-6c6c991916d6.png)

A demo would be available in my fork: https://huserben.github.io/usergroups/
Of course once you've set up yours I'll take it down, no need to duplicate :-)

The python script is now in a subfolder of the Illustrations, I'm not sure if you're happy with keeping it there or whether it should be in a different place. Just let me know and I could quickly change it ;-)